### PR TITLE
Pounamu over Nephrite for New Zealand localisation.

### DIFF
--- a/common/src/main/resources/assets/spelunkery/lang/en_au.json
+++ b/common/src/main/resources/assets/spelunkery/lang/en_au.json
@@ -1,0 +1,11 @@
+{
+  "tooltip.spelunkery.hammer_and_chisel_4": "  %1$s and use to convert Brick blocks to Chiselled form",
+
+  "block.spelunkery.sulfur": "Sulphur",
+  "block.spelunkery.saltpeter": "Saltpetre",
+  "block.spelunkery.sulfur_block": "Block of Sulphur",
+  "block.spelunkery.saltpeter_block": "Block of Saltpetre",
+
+  "block.spelunkery.gray_glowstick": "Grey Glowstick",
+  "block.spelunkery.light_gray_glowstick": "Light Grey Glowstick"
+}

--- a/common/src/main/resources/assets/spelunkery/lang/en_ca.json
+++ b/common/src/main/resources/assets/spelunkery/lang/en_ca.json
@@ -1,0 +1,11 @@
+{
+  "tooltip.spelunkery.hammer_and_chisel_4": "  %1$s and use to convert Brick blocks to Chiselled form",
+
+  "block.spelunkery.sulfur": "Sulphur",
+  "block.spelunkery.saltpeter": "Saltpetre",
+  "block.spelunkery.sulfur_block": "Block of Sulphur",
+  "block.spelunkery.saltpeter_block": "Block of Saltpetre",
+
+  "block.spelunkery.gray_glowstick": "Grey Glowstick",
+  "block.spelunkery.light_gray_glowstick": "Light Grey Glowstick"
+}

--- a/common/src/main/resources/assets/spelunkery/lang/en_gb.json
+++ b/common/src/main/resources/assets/spelunkery/lang/en_gb.json
@@ -1,0 +1,11 @@
+{
+  "tooltip.spelunkery.hammer_and_chisel_4": "  %1$s and use to convert Brick blocks to Chiselled form",
+
+  "block.spelunkery.sulfur": "Sulphur",
+  "block.spelunkery.saltpeter": "Saltpetre",
+  "block.spelunkery.sulfur_block": "Block of Sulphur",
+  "block.spelunkery.saltpeter_block": "Block of Saltpetre",
+
+  "block.spelunkery.gray_glowstick": "Grey Glowstick",
+  "block.spelunkery.light_gray_glowstick": "Light Grey Glowstick"
+}

--- a/common/src/main/resources/assets/spelunkery/lang/en_nz.json
+++ b/common/src/main/resources/assets/spelunkery/lang/en_nz.json
@@ -1,0 +1,45 @@
+{
+  "tooltip.spelunkery.hammer_and_chisel_4": "  %1$s and use to convert Brick blocks to Chiselled form",
+  "advancements.spelunkery.carved_nephrite.description": "Craft some Carved Pounamu",
+  "advancements.spelunkery.nephrite_charm.description": "Obtain a Pounamu Charm",
+  "advancements.spelunkery.nephrite_chunk.description": "Mine Pounamu and collect a Pounamu Chunk",
+
+  "tooltip.spelunkery.carved_nephrite_3": "  Use with a Pounamu Siphon, Fountain, and Diode",
+  "tooltip.spelunkery.nephrite_fountain_1": "  Drains Charge from Carved Pounamu, converts to XP orbs",
+  "tooltip.spelunkery.nephrite_fountain_2": "  Will only drain Charge from the Pounamu it is placed on",
+  "tooltip.spelunkery.nephrite_siphon_2": "  Converts to Charge split among adjacent Carved Pounamu",
+  "tooltip.spelunkery.nephrite_diode_1": "  Transfers Charge from Carved Pounamu it's facing to the opposite side",
+
+  "material.spelunkery.nephrite": "Pounamu Material",
+
+  "item.spelunkery.nephrite_chunk": "Pounamu Chunk",
+  "block.spelunkery.raw_nephrite": "Raw Pounamu",
+  "block.spelunkery.nephrite": "Pounamu",
+  "block.spelunkery.nephrite_slab": "Pounamu Slab",
+  "block.spelunkery.nephrite_stairs": "Pounamu Stairs",
+  "block.spelunkery.nephrite_wall": "Pounamu Wall",
+
+  "block.spelunkery.polished_nephrite": "Polished Pounamu",
+  "block.spelunkery.polished_nephrite_slab": "Polished Pounamu Slab",
+  "block.spelunkery.polished_nephrite_stairs": "Polished Pounamu Stairs",
+  "block.spelunkery.polished_nephrite_wall": "Polished Pounamu Wall",
+
+  "block.spelunkery.polished_nephrite_bricks": "Polished Pounamu Bricks",
+  "block.spelunkery.polished_nephrite_brick_slab": "Polished Pounamu Brick Slab",
+  "block.spelunkery.polished_nephrite_brick_stairs": "Polished Pounamu Brick Stairs",
+  "block.spelunkery.polished_nephrite_brick_wall": "Polished Pounamu Brick Wall",
+
+  "block.spelunkery.carved_nephrite": "Carved Pounamu",
+  "block.spelunkery.nephrite_siphon": "Pounamu Siphon",
+  "block.spelunkery.nephrite_fountain": "Pounamu Fountain",
+  "block.spelunkery.nephrite_diode": "Pounamu Diode",
+  "item.spelunkery.nephrite_charm": "Pounamu Charm",
+
+  "block.spelunkery.sulfur": "Sulphur",
+  "block.spelunkery.saltpeter": "Saltpetre",
+  "block.spelunkery.sulfur_block": "Block of Sulphur",
+  "block.spelunkery.saltpeter_block": "Block of Saltpetre",
+
+  "block.spelunkery.gray_glowstick": "Grey Glowstick",
+  "block.spelunkery.light_gray_glowstick": "Light Grey Glowstick"
+}


### PR DESCRIPTION
Renames Nephrite to Pounamu for Kiwis (like myself), as Pounamu is essentially New Zealand's native Nephrite Jade and Spelunkery's uses for it fit with New Zealand's spiritual and cultural significance of Pounamu.

I could have equally translated it as Greenstone, and even though it would fit with vanilla's Redstone naming, I think Pounamu is more fun and relevant, and unless we get a full translation of Minecraft in te reo Māori, I think representing it in New Zealand English is the next best thing.

For consistency, I've also included en_gb, en_au, and en_ca with only British spellings of words that also exist in en_nz as it felt odd if I only included those spellings in en_nz; Includes grey instead of gray, sulphur instead of sulfur, saltpetre instead of saltpeter, and chiselled instead of chiseled.


<img width="671" height="211" alt="image" src="https://github.com/user-attachments/assets/5aa6ac93-3441-4a86-a4f3-d2602ed6ec8c" />

This PR targets 1.21.1 but I can make ones for the other versions if desired as I vaguely remember localisation keys being a little different between versions but haven't actually checked if they effect these localisations.
